### PR TITLE
Fix package.json entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@appcues/expo-config",
   "version": "4.0.0-alpha.4",
   "description": "Expo module to integrate Appcues push notifications",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "plugin/build/index.js",
+  "types": "plugin/build/index.d.ts",
   "scripts": {
     "build": "expo-module build",
     "clean": "expo-module clean",


### PR DESCRIPTION
One (hopefully) last footgun. Between alpha.3 and alpha.4 releases I did a `git clean` which deleted a lingering gitignored `./build` directory that had the build output from the original expo module template. You can see this being uploaded to npm:

<img width="796" alt="Screenshot 2024-05-15 at 1 36 37 PM" src="https://github.com/appcues/appcues-expo-module/assets/845681/88aefa26-aaa1-4094-8f22-1f6211909851">

We don't want those files, but the fact that they existed meant the `package.json` entries for `main` and `types` resolved to _something_. With those files missing, I'd get

```
CommandError: Failed to resolve plugin for module "@appcues/expo-config" relative to "[PATH]"
```

Updating to the correct path means everything will work nicely, no random files holding things together.