### PR TITLE
Add compatibility with expo-build-properties ios.useFrameworks setting

### DIFF
--- a/plugin/src/iosConstants.ts
+++ b/plugin/src/iosConstants.ts
@@ -8,6 +8,7 @@ export const APPCUES_NSE_TARGET = {
 
 export const PODFILE_SNIPPET = `
 target '${APPCUES_NSE_TARGET.NAME}' do
+  use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']
   pod '${APPCUES_NSE_TARGET.POD_NAME}', '4.0.0'
 end
 `;


### PR DESCRIPTION
The `expo-build-properties` plugin has a setting to set the cocopods `use_frameworks!` option:

```js
{
  "expo": {
    ..
    "plugins": [
      ..
      [
        "expo-build-properties",
        {
          "ios": {
            "useFrameworks": "static"
          }
        }
      ]
    ]
  }
}
```

Other libraries require using this setting (eg [@react-native-firebase Expo configuration instructions](https://rnfirebase.io/#configure-react-native-firebase-modules)) and so we need to add it to our podfile snippet.

Fixes #16 